### PR TITLE
Prepare the chrome extension when installing the agent

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -378,4 +378,32 @@ ohai "Checking espresso-agent version..."
 check_espresso_agent_version "$AGENT_VERSION"
 
 ohai "Installation successful!"
+
+get_latest_extension() {
+  extension_url=$(curl --silent https://expresso-agent-1.s3.us-east-1.amazonaws.com/chrome-extension/latest)
+
+  filename=$(basename "$extension_url")
+  local_extension_path="/tmp/$filename"
+  EXTENSION_VERSION=$(echo "$extension_url" | sed -E 's/.*-([0-9]+\.[0-9]+\.[0-9]+)\.zip/\1/')
+  EXTENSION_DESTINATION="/Library/Application Support/EspressoLabs"
+
+  echo "Downloading extension: $extension_url"
+  curl -L --progress-bar "$extension_url" -o "$local_extension_path"
+  echo "Downloaded to $local_extension_path"
+
+  execute_sudo mkdir -p "$EXTENSION_DESTINATION"
+  execute_sudo unzip -qq -o "$local_extension_path" -d "$EXTENSION_DESTINATION"
+  execute_sudo chmod -R 777 "$EXTENSION_DESTINATION/chrome-extension"
+}
+
+ohai "Downloading the latest extension..."
+get_latest_extension
+
+ohai "You can now enable the Chrome Extension"
+
+echo "    To enable the extension:"
+echo "     1. Open Chrome and navigate to 'chrome://extensions/'."
+echo "     2. Enable 'Developer mode' (toggle in the top-right corner)."
+echo "     3. Click 'Load unpacked' and select the folder: $EXTENSION_DESTINATION/chrome-extension"
+
 ring_bell


### PR DESCRIPTION
When the agent installer is executed, the Chrome Extension is staged in a known location. This way users can follow the provided instructions to enable the extension.

At the end of the installation, there are instructions:
```
==> You can now enable the Chrome Extension
    To enable the extension:
     1. Open Chrome and navigate to 'chrome://extensions/'.
     2. Enable 'Developer mode' (toggle in the top-right corner).
     3. Click 'Load unpacked' and select the folder: {PATH}
```   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The installation process now automatically downloads, extracts, and installs the latest Chrome extension.
  - Enhanced messaging guides users on enabling the Chrome extension after installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->